### PR TITLE
Refactor `serve` function to facilitate middleware usage

### DIFF
--- a/example/Middleware.purs
+++ b/example/Middleware.purs
@@ -1,0 +1,70 @@
+module Example.Middleware where
+
+import Prelude
+
+import Control.Monad.Except (ExceptT)
+import Control.Monad.Reader (class MonadReader, ReaderT, local, runReaderT)
+import Control.Monad.Reader.Class (class MonadAsk, ask)
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype, un)
+import Effect (Effect)
+import Effect.Aff (Aff)
+import Effect.Class (class MonadEffect)
+import Effect.Console (log)
+import Node.HTTP (createServer, listen)
+import Nodetrout (HTTPError, Request, makeRouter, serveRouter)
+import Text.Smolder.HTML (span)
+import Text.Smolder.Markup (text)
+import Type.Proxy (Proxy(..))
+import Type.Trout (type (:=), Resource)
+import Type.Trout.ContentType.HTML (class EncodeHTML, HTML)
+import Type.Trout.Method (Get)
+
+newtype Message = Message String
+
+derive instance newtypeMessage :: Newtype Message _
+
+instance encodeHTMLMessage :: EncodeHTML Message where
+  encodeHTML = un Message >>> text >>> span
+
+newtype AppM a = AppM (ReaderT Message Aff a)
+
+derive instance newtypeAppM :: Newtype (AppM a) _
+
+derive newtype instance functorAppM :: Functor AppM
+derive newtype instance applyAppM :: Apply AppM
+derive newtype instance applicativeAppM :: Applicative AppM
+derive newtype instance bindAppM :: Bind AppM
+derive newtype instance monadAppM :: Monad AppM
+derive newtype instance monadEffectAppM :: MonadEffect AppM
+derive newtype instance monadAskMessageAppM :: MonadAsk Message AppM
+derive newtype instance monadReaderMessageAppM :: MonadReader Message AppM
+
+runAppM :: forall a. Message -> AppM a -> Aff a
+runAppM message = flip runReaderT message <<< un AppM
+
+type Site = "message" := Resource (Get Message HTML)
+
+site :: Proxy Site
+site = Proxy
+
+resources :: { message :: { "GET" :: ExceptT HTTPError AppM Message } }
+resources = { message: { "GET": ask } }
+
+middleware
+  :: forall content
+   . (Request -> ExceptT HTTPError AppM content)
+  -> Request
+  -> ExceptT HTTPError AppM content
+middleware next req =
+  local addGreeting $ next req
+  where
+    addGreeting :: Message -> Message
+    addGreeting (Message m) = Message $ m <> " From middleware!"
+
+main :: Effect Unit
+main = do
+  let router = middleware $ makeRouter site resources
+  server <- createServer $ serveRouter router (runAppM $ Message "Hello, Sailor!") (const $ pure unit)
+
+  listen server { hostname: "0.0.0.0", port: 3000, backlog: Nothing } $ log "Listening on port 3000..."

--- a/src/Nodetrout.purs
+++ b/src/Nodetrout.purs
@@ -1,5 +1,9 @@
 -- | This module exports Nodetrout's public API.
-module Nodetrout (serve, serve', module Error) where
+module Nodetrout
+  ( serve
+  , serve'
+  , module Exports
+  ) where
 
 import Prelude
 import Data.MediaType (MediaType)
@@ -43,9 +47,11 @@ import Nodetrout.Internal.Error
   , error503
   , error504
   , error505
-  ) as Error
+  ) as Exports
+import Nodetrout.Internal.Request (Request) as Exports
 import Nodetrout.Internal.Router (class Router)
 import Nodetrout.Internal.Server.Node as NS
+import Nodetrout.Internal.Server.Node (serveRouter, makeRouter) as Exports
 import Type.Proxy (Proxy)
 
 -- | Creates a `node-http`-compatible request handler of type


### PR DESCRIPTION
@nsaunders I'm opening a PR here so you can jot down your thoughts asynchronously and we can take the conversation out of slack.

This PR breaks apart `serve` into two functions -- `makeRouter` and `serveRouter`. The external API to `serve` does not change, but this adds the ability for a user to call `makeRouter` first, wrap this router in middleware and then serve the router with `serveRouter`. A router effectively has the following signature (note that `Request` is `Nodetrout.Request`):

```purescript
forall m r. Monad m => MonadEffect m => Request -> ExceptT HTTPError m r
```

I was inspired by the [middleware approach of HTTPure](https://github.com/cprussin/purescript-httpure/blob/a12e63b87984e3df3cf36bf931392f97790906fd/docs/Middleware.md).

Now, a middleware is any function with this signature:

```purescript
   forall m r
 . Monad m
=> MonadEffect m
=> (Request -> ExceptT HTTPError m r)
-> Request
-> ExceptT HTTPError m r
```

Here's a middleware that would do nothing other than log "hello" before handling the request:

```purescript
middleware
  :: forall m r
   . Monad m
  => MonadEffect m
  => (Request -> ExceptT HTTPError m r)
  -> Request
  -> ExceptT HTTPError m r
middleware next req = do
  Console.log "hello"
  next req
```

I believe this approach is superior to wrapping the `node-http`-compatible handler returned by `server` for several reasons:

1. It doesn't involve writing to a `response` in a side-effect-y manner and returning `Effect Unit`s.
2. It has access to the application monad, meaning it can do things like add request-scoped values to a `ReaderT`, among other things.
3. Middleware composition is just composing several middleware functions. When composed with `<<<`, they are executed left-to-right (similar to lenses).

Let me know what you think, thanks for taking the time to review this.