### PR TITLE
Support more MediaTypes, and don't evaluate Requests that the client can't Accept

### DIFF
--- a/src/Nodetrout/Internal/Router.purs
+++ b/src/Nodetrout/Internal/Router.purs
@@ -1,12 +1,14 @@
 -- | This module contains the routing logic.
-module Nodetrout.Internal.Router (class Router, route) where
+module Nodetrout.Internal.Router (class DeferredAllMimeRender, class Router, deferredMimeRenderers, route) where
   
 import Prelude
+
 import Control.Monad.Except (ExceptT, runExceptT, throwError)
 import Control.Monad.Trans.Class (lift)
 import Data.Array (null)
 import Data.Either (Either(..), note)
 import Data.HTTP.Method (fromString) as Method
+import Data.List.NonEmpty (NonEmptyList)
 import Data.Maybe (Maybe(..))
 import Data.MediaType (MediaType)
 import Data.Symbol (SProxy(..), reflectSymbol)
@@ -14,38 +16,17 @@ import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Nodetrout.Internal.Content (negotiate) as Content
-import Nodetrout.Internal.Error (select) as Error
 import Nodetrout.Internal.Error (HTTPError, error400, error404, error405)
+import Nodetrout.Internal.Error (select) as Error
 import Nodetrout.Internal.Request (Request)
-import Nodetrout.Internal.Request
-  ( headerValue
-  , method
-  , path
-  , queryParamValue
-  , queryParamValues
-  , removePath
-  , stringBody
-  , unconsPath
-  ) as Request
+import Nodetrout.Internal.Request (headerValue, method, path, queryParamValue, queryParamValues, removePath, stringBody, unconsPath) as Request
 import Prim.Row (class Cons, class Lacks) as Row
 import Record (delete, get) as Record
 import Type.Data.Symbol (class IsSymbol)
 import Type.Proxy (Proxy(..))
-import Type.Trout
-  ( type (:<|>)
-  , type (:>)
-  , type (:=)
-  , Capture
-  , CaptureAll
-  , Header
-  , Lit
-  , QueryParam
-  , QueryParams
-  , ReqBody
-  , Resource
-  )
 import Type.Trout (Method) as Trout
-import Type.Trout.ContentType (class AllMimeRender, class MimeParse, allMimeRender, mimeParse)
+import Type.Trout (type (:<|>), type (:>), type (:=), Capture, CaptureAll, Header, Lit, QueryParam, QueryParams, ReqBody, Resource)
+import Type.Trout.ContentType (class AllMimeRender, class HasMediaType, class MimeParse, class MimeRender, allMimeRender, getMediaType, mimeParse, mimeRender)
 import Type.Trout.Header (class FromHeader, fromHeader)
 import Type.Trout.PathPiece (class FromPathPiece, fromPathPiece)
 
@@ -202,15 +183,15 @@ instance routerReqBody ::
 instance routerMethod ::
   ( Monad m
   , IsSymbol method
-  , AllMimeRender body contentTypes rendered
+  , DeferredAllMimeRender body contentTypes rendered
   , Row.Cons method (ExceptT HTTPError m body) handlers' handlers
   ) => Router (Trout.Method method body contentTypes) (Record handlers) m (Tuple MediaType rendered) where
   route layout handlers request depth = do
     let method = SProxy :: SProxy method
     when (not $ null $ Request.path request) $ throwError error404 { priority = depth }
     when (Request.method request /= Method.fromString (reflectSymbol method)) $ throwError error405 { priority = depth }
-    body <- Record.get method handlers
-    content <- Content.negotiate request $ allMimeRender (Proxy :: Proxy contentTypes) body
+    let runBody = Record.get method handlers
+    content <- Content.negotiate request (deferredMimeRenderers (Proxy :: Proxy contentTypes)) runBody
     pure content
 
 instance routerResource ::
@@ -218,3 +199,35 @@ instance routerResource ::
   , Router layout handlers m result
   ) => Router (Resource layout) handlers m result where
   route _ = route (Proxy :: Proxy layout)
+
+
+-- | Workaround for AllMimeRender's design somewhat defeating its own point
+-- | There's no way to determine at runtime if a given `a` *can* be rendered as `ct` with some
+-- | given `MediaType`. You need to supply an `a`, and then iterate through the returned list,
+-- | in other words, `AllMimeRender` forces you to evaluate your endpoint before feeding
+-- | the result into `allMimeRender`. Of course, there's no sense in evaluating an endpoint if
+-- | the client can't consume it. In fact, it's very dangerous, because then you'd potentially perform
+-- | a stateful action but then tell the client we couldn't serve their request with the implication
+-- | that it was refused.
+-- |
+-- | This is also convenient because now Nodetrout doesn't need a bunch of repetitive
+-- | AllMimeRender instances to make routers for non-alt types.
+-- | i.e., you dont have to make `instance HasMediaType ct` and `MimeRender a ct b`
+-- | only to then make `instance AllMimeRender a ct b` which just returns a tuple of the two...
+class DeferredAllMimeRender a cts b | a -> b, cts -> b where
+  deferredMimeRenderers :: Proxy cts -> NonEmptyList (Tuple MediaType (a -> b))
+
+instance deferredAllMimeRenderExtAlt ::
+  ( HasMediaType ct1
+  , MimeRender a ct1 b
+  , DeferredAllMimeRender a ct2 b
+  ) => DeferredAllMimeRender a (ct1 :<|> ct2) b where
+    deferredMimeRenderers _ = pure (Tuple (getMediaType p) (mimeRender p)) <> (deferredMimeRenderers p')
+      where p = Proxy :: Proxy ct1
+            p' = Proxy :: Proxy ct2
+else instance deferredAllMimeRenderExtSingle ::
+  ( HasMediaType ct
+  , MimeRender a ct b
+  ) => DeferredAllMimeRender a ct b where
+    deferredMimeRenderers _ = pure (Tuple (getMediaType p) (mimeRender p))
+      where p = Proxy :: Proxy ct

--- a/src/Nodetrout/Internal/Router.purs
+++ b/src/Nodetrout/Internal/Router.purs
@@ -26,7 +26,7 @@ import Type.Data.Symbol (class IsSymbol)
 import Type.Proxy (Proxy(..))
 import Type.Trout (Method) as Trout
 import Type.Trout (type (:<|>), type (:>), type (:=), Capture, CaptureAll, Header, Lit, QueryParam, QueryParams, ReqBody, Resource)
-import Type.Trout.ContentType (class AllMimeRender, class HasMediaType, class MimeParse, class MimeRender, allMimeRender, getMediaType, mimeParse, mimeRender)
+import Type.Trout.ContentType (class HasMediaType, class MimeParse, class MimeRender, getMediaType, mimeParse, mimeRender)
 import Type.Trout.Header (class FromHeader, fromHeader)
 import Type.Trout.PathPiece (class FromPathPiece, fromPathPiece)
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,17 +2,17 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Except (runExceptT)
-import Data.Argonaut (encodeJson, stringify)
+import Control.Monad.Except (runExceptT, throwError)
+import Data.Argonaut (decodeJson, encodeJson, jsonParser, stringify)
 import Data.Array (filter)
 import Data.Either (Either(..))
 import Data.Foldable (find)
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.MediaType (MediaType)
 import Data.MediaType.Common (applicationJSON, textHTML)
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
-import Effect.Aff (Aff, launchAff_)
+import Effect.Aff (Aff, error, launchAff_)
 import Effect.Aff.Class (class MonadAff)
 import Foreign.Object (Object)
 import Foreign.Object (insert, singleton) as FO
@@ -126,3 +126,48 @@ main = launchAff_ $ runSpec [consoleReporter] do
         Right (Tuple mediaType content) -> do
           mediaType `shouldEqual` applicationJSON
           content `shouldEqual` (stringify $ encodeJson Default)
+
+    let successfulStatefulReadRequest = do
+          result <- processRequest $ defaultRequest { url = "/stateful/read" }
+          case result of
+            Left err-> throwError $ error $ "Request failed unexpectedly: " <> show err
+            Right (Tuple mediaType content) -> do
+              mediaType `shouldEqual` applicationJSON
+              case decodeJson =<< jsonParser content of
+                Left err -> throwError $ error $ "Request failed unexpectedly: " <> show err
+                Right res -> pure res
+    let defaultHeaders = defaultRequest.headers
+        mkIncrementRequest acceptHeader = 
+          defaultRequest { method = "POST" 
+                         , url = "/stateful/increment"
+                         , headers = fromMaybe defaultHeaders 
+                              (flip (FO.insert "accept") defaultHeaders <$> acceptHeader)
+                         }
+        testStatefulIncrement acceptHeader = do
+          initialState :: Int <- successfulStatefulReadRequest
+          modifyResult <- processRequest (mkIncrementRequest acceptHeader)
+          case modifyResult of
+            Left err -> fail $ "Request failed unexpectedly: " <> show err
+            Right (Tuple mediaType content) -> do
+              mediaType `shouldEqual` applicationJSON
+              case decodeJson =<< jsonParser content of
+                Left err -> throwError $ error $ "Decoding response failed unexpectedly: " <> show err
+                Right returnedState -> do
+                  returnedState `shouldEqual` initialState
+                  finalState <- successfulStatefulReadRequest
+                  finalState `shouldEqual` (returnedState + 1)
+
+    it "should process the request if the client supplies no Accept" $
+      testStatefulIncrement Nothing
+    it "should process the request if the client supplies an Accept that we can handle" $
+      testStatefulIncrement (Just "application/json")
+
+    it "should NOT process the request if the client can't accept the returned value" do
+      initialState :: Int <- successfulStatefulReadRequest
+      modifyResult <- processRequest $ mkIncrementRequest (Just "absolutely/unacceptable")
+      case modifyResult of
+        Right res -> fail $ "Request succeeded unexpectedly with returned value: " <> show res
+        Left _ -> do
+          finalState <- successfulStatefulReadRequest
+          initialState `shouldEqual` finalState
+      

--- a/test/TestSite.js
+++ b/test/TestSite.js
@@ -1,0 +1,10 @@
+let someStatefulVariable = 0;
+exports.incrementStatefulVariable = function() {
+  let oldValue = someStatefulVariable;
+  someStatefulVariable += 1;
+  return oldValue;
+}
+
+exports.getStatefulVariable = function () {
+  return someStatefulVariable;
+}


### PR DESCRIPTION
This PR tackles both of the issues brought up in #7, as well as adds tests for them. I'm tempted to say that the whole `DeferredAllMimeRender` typeclass belongs in `trout` itself -- maybe I'm misunderstanding what's going on in `hypertrout`, but looking from the code (haven't ran a server with HT to verify) it seems like it's susceptible to the same "evaluating requests that can't be served" that was brought up wrt Nodetrout. Putting that typeclass into trout -- or even just changing the definition of `AllMimeRender` to match `DeferredAllMimeRender` as it honestly seems more in line with its intended purpose anyway -- could resolve that for both.