### PR TITLE
Support `MimeParse`-ing on things other than `Strings`, and allow mixing and matching `MimeRender` destination types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - wget -O $HOME/spago.tar.gz https://github.com/spacchetti/spago/releases/download/$SPAGO_VER/linux.tar.gz
   - tar -xvf $HOME/purescript.tar.gz -C $HOME/
   - tar -xvf $HOME/spago.tar.gz -C $HOME/
+  - npm install stream-buffers
   - chmod a+x $HOME/purescript/purs
   - chmod a+x $HOME/spago
   - spago install

--- a/spago.dhall
+++ b/spago.dhall
@@ -6,6 +6,7 @@
     "https://github.com/nsaunders/purescript-nodetrout.git"
 , dependencies =
     [ "argonaut"
+    , "bytestrings"
     , "b64"
     , "console"
     , "effect"

--- a/src/Nodetrout.purs
+++ b/src/Nodetrout.purs
@@ -2,6 +2,7 @@
 module Nodetrout (serve, serve', module Error) where
 
 import Prelude
+
 import Data.MediaType (MediaType)
 import Data.Tuple (Tuple)
 import Effect (Effect)
@@ -9,6 +10,7 @@ import Effect.Aff (Aff)
 import Effect.Class (class MonadEffect)
 import Effect.Exception (Error)
 import Node.HTTP (Request, Response) as NH
+import Nodetrout.Internal.Content (class ResponseWritable)
 import Nodetrout.Internal.Error
   ( HTTPError
   , error300
@@ -55,7 +57,7 @@ serve
   :: forall layout handlers m content
    . Monad m
   => MonadEffect m
-  => NS.ResponseWritable content
+  => ResponseWritable content
   => Router layout (Record handlers) m (Tuple MediaType content)
   => Proxy layout
   -> Record handlers
@@ -70,7 +72,7 @@ serve = NS.serve -- Note that the `serve` function is redeclared so that it appe
 -- | `ExceptT HTTPError Aff`, i.e. the inner monad is already `Aff`.
 serve'
   :: forall layout handlers content
-   . NS.ResponseWritable content
+   . ResponseWritable content
   => Router layout (Record handlers) Aff (Tuple MediaType content)
   => Proxy layout
   -> Record handlers

--- a/src/Nodetrout/Internal/Content.purs
+++ b/src/Nodetrout/Internal/Content.purs
@@ -8,12 +8,12 @@ import Control.Monad.Except (ExceptT, throwError)
 import Data.Array (catMaybes, elem, elemIndex, length)
 import Data.List.NonEmpty (NonEmptyList, find, head, reverse, sortBy)
 import Data.Maybe (Maybe(..))
-import Data.MediaType (MediaType(..))
-import Data.String (indexOf, split, trim)
+import Data.MediaType (MediaType)
+import Data.String (split, trim)
 import Data.String.Pattern (Pattern(..))
 import Data.Tuple (Tuple(..), fst)
 import Nodetrout.Internal.Error (HTTPError, error406)
-import Nodetrout.Internal.Request (Request, headerValue)
+import Nodetrout.Internal.Request (Request, headerValue, toUnparameterizedMediaType)
 
 data Acceptable
   = Required (Array MediaType)
@@ -52,11 +52,7 @@ getAcceptable =
       let
         values = trim <$> split (Pattern ",") header
         acceptable = if not $ "*/*" `elem` values then Required else Preferred
-        asUnparameterizedMediaType v =
-          if indexOf (Pattern ";") v == Nothing 
-          then Just (MediaType v)
-          else Nothing
-        mimeTypes = catMaybes $ values <#> asUnparameterizedMediaType
+        mimeTypes = catMaybes $ values <#> toUnparameterizedMediaType
       in
         if (length mimeTypes == 0)
           then throwError error406 { details = Just "The requested media types are unsupported." }

--- a/src/Nodetrout/Internal/Server/Node.purs
+++ b/src/Nodetrout/Internal/Server/Node.purs
@@ -1,5 +1,5 @@
 -- | This module contains the request handling logic related to `node-http`.
-module Nodetrout.Internal.Server.Node (class ResponseWritable, serve, writeResponse) where
+module Nodetrout.Internal.Server.Node (serve) where
 
 import Prelude
 
@@ -19,7 +19,8 @@ import Node.Buffer (concat) as Buffer
 import Node.Encoding (Encoding(UTF8))
 import Node.HTTP (Request, Response) as NH
 import Node.HTTP (requestHeaders, requestMethod, requestAsStream, requestURL, responseAsStream, setHeader, setStatusCode)
-import Node.Stream (Writable, end, onData, onEnd, writeString) as Stream
+import Node.Stream (end, onData, onEnd, writeString) as Stream
+import Nodetrout.Internal.Content (class ResponseWritable, writeResponse)
 import Nodetrout.Internal.Request (Request(..))
 import Nodetrout.Internal.Router (class Router, route)
 import Type.Proxy (Proxy)
@@ -102,10 +103,3 @@ serve layout handlers runM onError req res =
           setHeader res "content-type" contentType
           writeResponse rs content
           Stream.end rs $ pure unit
-
--- | Specifies how to write `content` to a response stream.
-class ResponseWritable content where
-  writeResponse :: Stream.Writable () -> content -> Effect Unit
-
-instance responseWritableString :: ResponseWritable String where
-  writeResponse stream content = Stream.writeString stream UTF8 content (pure unit) *> pure unit

--- a/test/Main.js
+++ b/test/Main.js
@@ -1,0 +1,12 @@
+"use strict";
+const streamBuffers = require('stream-buffers');
+
+exports.mkStreamBuffer = function (pure) {
+    return pure(new streamBuffers.WritableStreamBuffer());
+}
+
+exports.getStreamBufferContents = function(pure) {
+  return function(sb) {
+    return pure(sb.getContents());
+  }
+}

--- a/test/TestSite.purs
+++ b/test/TestSite.purs
@@ -6,6 +6,7 @@ import Control.Monad.Except (ExceptT, throwError)
 import Data.Argonaut (class DecodeJson, class EncodeJson, encodeJson, jsonEmptyObject)
 import Data.Array (filter)
 import Data.ByteString (ByteString)
+import Data.ByteString (toUTF8) as ByteString
 import Data.Either (Either(Left))
 import Data.Foldable (find, foldr)
 import Data.Maybe (Maybe(..))
@@ -45,8 +46,8 @@ magicMimeTypeRenderString = "It's magic, you know!"
 instance hasMediaTypeMagic :: HasMediaType MagicContentType where
   getMediaType _ = magicMimeType
 
-instance magicallyRenderMagicContentType :: MimeRender a MagicContentType String where
-  mimeRender _ _ = magicMimeTypeRenderString
+instance magicallyRenderMagicContentType :: MimeRender a MagicContentType ByteString where
+  mimeRender _ _ = ByteString.toUTF8 magicMimeTypeRenderString
 
 newtype Message = Message { id :: Int, content :: String, unread :: Boolean }
 


### PR DESCRIPTION
Hey!

This PR adds a couple of nifty features. One is that you can now `MimeParse` stuff other than Strings -- handy for when your request body might not be valid UTF-8 (e.g., is binary). Additionally, you can now mix and match different kinds of `MimeRender` instances -- previously, if some routes `MimeRender`ed down to a `String` and others to a `ByteString`, for example -- you'd get a type mismatch (`MimeRender a b String` vs `MimeRender c d ByteString`) since not all of the final `rendered` types were the same, and the compiler picked whichever came first.

To enable the latter, I had to generalize how responses are written to the output stream (hence the `ResponseWriter` type), and needed to add an NPM package to facilitate testing (`stream-buffers`, which allow you to treat a `Buffer` as a node stream).

You may find there is no obvious test for the mix-and-match MimeRender functionality -- the test is the test suite itself compiling! Note that MagicContentType now `MimeRender`s to a ByteString, whereas there are remaining HTML and JSON endpoints which `MimeRender` to `String`:
```diff
@@ -44,8 +46,8 @@ magicMimeTypeRenderString = "It's magic, you know!"
 instance hasMediaTypeMagic :: HasMediaType MagicContentType where
   getMediaType _ = magicMimeType
 
-instance magicallyRenderMagicContentType :: MimeRender a MagicContentType String where
-  mimeRender _ _ = magicMimeTypeRenderString
+instance magicallyRenderMagicContentType :: MimeRender a MagicContentType ByteString where
+  mimeRender _ _ = ByteString.toUTF8 magicMimeTypeRenderString
```